### PR TITLE
Add more conv2D layers before the primary capsules

### DIFF
--- a/capsulelayers.py
+++ b/capsulelayers.py
@@ -9,9 +9,8 @@ Author: Xifeng Guo, E-mail: `guoxifeng1990@163.com`,
 Github: `https://github.com/XifengGuo/CapsNet-Keras`
 """
 
-from keras import initializers, layers
+from keras import activations, initializers, layers
 import keras.backend as K
-import tensorflow as tf
 
 
 class Length(layers.Layer):
@@ -175,14 +174,14 @@ class CapsuleLayer(layers.Layer):
         # Begin: Routing algorithm ---------------------------------------------------------------#
         # The prior for coupling coefficient, initialized as zeros.
         # b.shape = [None, self.num_capsule, self.input_num_capsule].
-        b = tf.zeros(
+        b = K.zeros(
             shape=[K.shape(inputs_hat)[0], self.num_capsule, self.input_num_capsule]
         )
 
         assert self.routings > 0, "The routings should be > 0."
         for i in range(self.routings):
             # c.shape=[batch_size, num_capsule, input_num_capsule]
-            c = tf.nn.softmax(b, dim=1)
+            c = activations.softmax(b, axis=1)
 
             # c.shape =  [batch_size, num_capsule, input_num_capsule]
             # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -347,6 +347,8 @@ if __name__ == "__main__":
     else:
         raise ValueError("Available datasets: 'mnist', 'cifar10'.")
 
+    (x_train, y_train), (x_test, y_test) = load_cifar10()
+
     # define model
     model, eval_model, manipulate_model = CapsNet(
         input_shape=x_train.shape[1:],

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
         "--dataset", default="mnist", help="Available datasets: {'mnist'}, 'cifar10'."
     )
     args = parser.parse_args()
-    print(f"\nargs: {args}\n")
+    print(args)
 
     if not os.path.exists(args.save_dir):
         os.makedirs(args.save_dir)

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -44,15 +44,12 @@ def CapsNet(input_shape, n_class, routings):
     """
     x = layers.Input(shape=input_shape)
 
-    # Layer 1: Just a conventional Conv2D layer
-    conv1 = layers.Conv2D(
-        filters=256,
-        kernel_size=9,
-        strides=1,
-        padding="valid",
-        activation="relu",
-        name="conv1",
-    )(x)
+    # Conventional Conv2D layers but more than in Sabour+2017
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.AveragePooling2D((2, 2))(x)
+    x = layers.Conv2D(128, (3, 3), activation="relu")(x)
+    conv1 = layers.Conv2D(128, (3, 3), activation="relu")(x)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -327,9 +327,10 @@ if __name__ == "__main__":
         default=None,
         help="The path of the saved weights. Should be specified when testing",
     )
-    parser.add_argument(
-        "--data_augmentation", default=False, help="Do data augmentation."
-    )
+    parser.add_argument('--data_augmentation', dest='data_augmentation', action='store_true')
+    parser.add_argument('--no-data_augmentation', dest='data_augmentation', action='store_false')
+    parser.set_defaults(data_augmentation=False)
+
     args = parser.parse_args()
     print(args)
 

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -50,12 +50,6 @@ def CapsNet(input_shape, n_class, routings):
     pool1 = layers.AveragePooling2D((2, 2))(conv2)
     conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
     conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
-    print("conv1 shape", conv1.output_shape)
-    print("conv2 shape", conv2.output_shape)
-    print("pool1 shape", pool1.output_shape)
-    print("conv3 shape", conv3.output_shape)
-    print("conv4 shape", conv4.output_shape)
-    conv4 = layers.Reshape((-1, 128))(conv4)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
@@ -359,6 +353,9 @@ if __name__ == "__main__":
         routings=args.routings,
     )
     model.summary()
+
+    for layer in model.layers:
+        print(layer.output_shape)
 
     # train or test
     if args.weights is not None:  # init the model weights with provided one

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -50,12 +50,6 @@ def CapsNet(input_shape, n_class, routings):
     pool1 = layers.AveragePooling2D((2, 2))(conv2)
     conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
     conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
-    print("conv1 shape", conv1.output_shape)
-    print("conv2 shape", conv2.output_shape)
-    print("pool1 shape", pool1.output_shape)
-    print("conv3 shape", conv3.output_shape)
-    print("conv4 shape", conv4.output_shape)
-    conv4 = layers.Reshape((-1, 128))(conv4)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
@@ -338,6 +332,9 @@ if __name__ == "__main__":
         routings=args.routings,
     )
     model.summary()
+
+    for layer in model.layers:
+        print(layer.output_shape)
 
     # train or test
     if args.weights is not None:  # init the model weights with provided one

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -45,16 +45,16 @@ def CapsNet(input_shape, n_class, routings):
     x = layers.Input(shape=input_shape)
 
     # Conventional Conv2D layers but more than in Sabour+2017
-    conv1 = layers.Conv2D(64, (3, 3), activation="relu")(x)
-    conv2 = layers.Conv2D(64, (3, 3), activation="relu")(conv1)
-    pool1 = layers.AveragePooling2D((2, 2))(conv2)
-    conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
-    conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.AveragePooling2D((2, 2))(x)
+    x = layers.Conv2D(128, (3, 3), activation="relu")(x)
+    conv1 = layers.Conv2D(128, (3, 3), activation="relu")(x)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(
-        conv4, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
+        conv1, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
     )
 
     # Layer 3: Capsule layer. Routing algorithm works here.

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -308,7 +308,7 @@ if __name__ == "__main__":
         "--shift_fraction",
         default=0,
         type=float,
-        help="Fraction of pixels to shift at most in each direction.,
+        help="Fraction of pixels to shift at most in each direction.",
     )
     parser.add_argument(
         "--debug", action="store_true", help="Save weights by TensorBoard"

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -318,6 +318,9 @@ if __name__ == "__main__":
         default=None,
         help="The path of the saved weights. Should be specified when testing",
     )
+    parser.add_argument(
+        "--dataset", default="mnist", help="Available datasets: {'mnist'}, 'cifar10'."
+    )
     args = parser.parse_args()
     print(args)
 
@@ -325,8 +328,12 @@ if __name__ == "__main__":
         os.makedirs(args.save_dir)
 
     # load data
-    # (x_train, y_train), (x_test, y_test) = load_mnist()
-    (x_train, y_train), (x_test, y_test) = load_cifar10()
+    if args.dataset == "mnist":
+        (x_train, y_train), (x_test, y_test) = load_mnist()
+    elif args.dataset == "cifar10":
+        (x_train, y_train), (x_test, y_test) = load_cifar10()
+    else:
+        raise ValueError("Available datasets: 'mnist', 'cifar10'.")
 
     # define model
     model, eval_model, manipulate_model = CapsNet(

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -45,16 +45,13 @@ def CapsNet(input_shape, n_class, routings):
     x = layers.Input(shape=input_shape)
 
     # Conventional Conv2D layers but more than in Sabour+2017
-    conv1 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(x)
-    conv2 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(conv1)
-    conv3 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(conv2)
-    conv4 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(conv3)
-    conv5 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(conv4)
+    conv1 = layers.Conv2D(filters=64, kernel_size=(5, 5), activation="relu")(x)
+    conv2 = layers.Conv2D(filters=64, kernel_size=(5, 5), activation="relu")(conv1)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(
-        conv5, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
+        conv2, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
     )
 
     # Layer 3: Capsule layer. Routing algorithm works here.

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -45,16 +45,16 @@ def CapsNet(input_shape, n_class, routings):
     x = layers.Input(shape=input_shape)
 
     # Conventional Conv2D layers but more than in Sabour+2017
-    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
-    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
-    x = layers.AveragePooling2D((2, 2))(x)
-    x = layers.Conv2D(128, (3, 3), activation="relu")(x)
-    conv1 = layers.Conv2D(128, (3, 3), activation="relu")(x)
+    conv1 = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    conv2 = layers.Conv2D(64, (3, 3), activation="relu")(conv1)
+    pool1 = layers.AveragePooling2D((2, 2))(conv2)
+    conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
+    conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(
-        conv1, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
+        conv4, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
     )
 
     # Layer 3: Capsule layer. Routing algorithm works here.

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
         "--dataset", default="mnist", help="Available datasets: {'mnist'}, 'cifar10'."
     )
     args = parser.parse_args()
-    print(args)
+    print(f"\nargs: {args}\n")
 
     if not os.path.exists(args.save_dir):
         os.makedirs(args.save_dir)

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -340,8 +340,6 @@ if __name__ == "__main__":
     else:
         raise ValueError("Available datasets: 'mnist', 'cifar10'.")
 
-    (x_train, y_train), (x_test, y_test) = load_cifar10()
-
     # define model
     model, eval_model, manipulate_model = CapsNet(
         input_shape=x_train.shape[1:],

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -50,6 +50,11 @@ def CapsNet(input_shape, n_class, routings):
     pool1 = layers.AveragePooling2D((2, 2))(conv2)
     conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
     conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
+    print("conv1 shape", conv1.output_shape)
+    print("conv2 shape", conv2.output_shape)
+    print("pool1 shape", pool1.output_shape)
+    print("conv3 shape", conv3.output_shape)
+    print("conv4 shape", conv4.output_shape)
     conv4 = layers.Reshape((-1, 128))(conv4)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -322,7 +322,7 @@ if __name__ == "__main__":
         "--dataset", default="mnist", help="Available datasets: {'mnist'}, 'cifar10'."
     )
     args = parser.parse_args()
-    print(args)
+    print(f"\nargs: {args}\n")
 
     if not os.path.exists(args.save_dir):
         os.makedirs(args.save_dir)

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -45,13 +45,12 @@ def CapsNet(input_shape, n_class, routings):
     x = layers.Input(shape=input_shape)
 
     # Conventional Conv2D layers but more than in Sabour+2017
-    conv1 = layers.Conv2D(filters=64, kernel_size=(5, 5), activation="relu")(x)
-    conv2 = layers.Conv2D(filters=64, kernel_size=(5, 5), activation="relu")(conv1)
+    conv1 = layers.Conv2D(filters=64, kernel_size=(9, 9), activation="relu")(x)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(
-        conv2, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
+        conv1, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
     )
 
     # Layer 3: Capsule layer. Routing algorithm works here.

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -47,14 +47,14 @@ def CapsNet(input_shape, n_class, routings):
     # Conventional Conv2D layers but more than in Sabour+2017
     conv1 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(x)
     conv2 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(conv1)
-    pool1 = layers.AveragePooling2D((2, 2))(conv2)
-    conv3 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(pool1)
+    conv3 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(conv2)
     conv4 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(conv3)
+    conv5 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(conv4)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(
-        conv4, dim_capsule=8, n_channels=64, kernel_size=3, strides=1, padding="valid"
+        conv5, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
     )
 
     # Layer 3: Capsule layer. Routing algorithm works here.

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -45,11 +45,11 @@ def CapsNet(input_shape, n_class, routings):
     x = layers.Input(shape=input_shape)
 
     # Conventional Conv2D layers but more than in Sabour+2017
-    conv1 = layers.Conv2D(64, (3, 3), activation="relu")(x)
-    conv2 = layers.Conv2D(64, (3, 3), activation="relu")(conv1)
+    conv1 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(x)
+    conv2 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(conv1)
     pool1 = layers.AveragePooling2D((2, 2))(conv2)
-    conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
-    conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
+    conv3 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(pool1)
+    conv4 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(conv3)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
@@ -353,9 +353,6 @@ if __name__ == "__main__":
         routings=args.routings,
     )
     model.summary()
-
-    for layer in model.layers:
-        print(layer.output_shape)
 
     # train or test
     if args.weights is not None:  # init the model weights with provided one

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -186,7 +186,7 @@ def train(model, data, args):
             batch_size=args.batch_size,
             epochs=args.epochs,
             validation_data=[[x_test, y_test], [y_test, x_test]],
-            callbacks=[log, tb, checkpoint, lr_decay],
+            callbacks=[log, tb, checkpoint, lr_decay, timing],
         )
 
     print("Time per epoch", timing.times)

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -50,6 +50,7 @@ def CapsNet(input_shape, n_class, routings):
     pool1 = layers.AveragePooling2D((2, 2))(conv2)
     conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
     conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
+    conv4 = layers.Reshape((-1, 128))(conv4)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -335,6 +335,8 @@ if __name__ == "__main__":
     else:
         raise ValueError("Available datasets: 'mnist', 'cifar10'.")
 
+    (x_train, y_train), (x_test, y_test) = load_cifar10()
+
     # define model
     model, eval_model, manipulate_model = CapsNet(
         input_shape=x_train.shape[1:],

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -54,7 +54,7 @@ def CapsNet(input_shape, n_class, routings):
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(
-        conv4, dim_capsule=8, n_channels=64, kernel_size=9, strides=2, padding="valid"
+        conv4, dim_capsule=8, n_channels=64, kernel_size=3, strides=2, padding="valid"
     )
 
     # Layer 3: Capsule layer. Routing algorithm works here.

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -330,7 +330,9 @@ if __name__ == "__main__":
     parser.add_argument('--data_augmentation', dest='data_augmentation', action='store_true')
     parser.add_argument('--no-data_augmentation', dest='data_augmentation', action='store_false')
     parser.set_defaults(data_augmentation=False)
-
+    parser.add_argument(
+        "--dataset", default="mnist", help="Available datasets: {'mnist'}, 'cifar10'."
+    )
     args = parser.parse_args()
     print(args)
 
@@ -338,8 +340,12 @@ if __name__ == "__main__":
         os.makedirs(args.save_dir)
 
     # load data
-    # (x_train, y_train), (x_test, y_test) = load_mnist()
-    (x_train, y_train), (x_test, y_test) = load_cifar10()
+    if args.dataset == "mnist":
+        (x_train, y_train), (x_test, y_test) = load_mnist()
+    elif args.dataset == "cifar10":
+        (x_train, y_train), (x_test, y_test) = load_cifar10()
+    else:
+        raise ValueError("Available datasets: 'mnist', 'cifar10'.")
 
     # define model
     model, eval_model, manipulate_model = CapsNet(

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -324,7 +324,7 @@ if __name__ == "__main__":
     parser.add_argument('--no-data_augmentation', dest='data_augmentation', action='store_false')
     parser.set_defaults(data_augmentation=False)
     parser.add_argument(
-        "--dataset", default="mnist", help="Available datasets: {'mnist'}, 'cifar10'."
+        "--dataset", default="cifar10", help="Available datasets: {'cifar10'}, 'mnist'."
     )
     args = parser.parse_args()
     print(f"\nargs: {args}\n")

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -18,6 +18,7 @@ Result:
 Author: Xifeng Guo, E-mail: `guoxifeng1990@163.com`,
 Github: `https://github.com/XifengGuo/CapsNet-Keras`
 """
+import copy
 
 from keras import layers, models, optimizers
 from keras import backend as K
@@ -145,42 +146,25 @@ def train(model, data, args):
         metrics={"capsnet": "accuracy"},
     )
 
-    if args.data_augmentation:
-
-        def train_generator(x, y, batch_size, shift_fraction=0.):
-            # shift up to 2 pixel for MNIST
-            train_datagen = ImageDataGenerator(
-                width_shift_range=shift_fraction, height_shift_range=shift_fraction
-            )
-            generator = train_datagen.flow(x, y, batch_size=batch_size)
-            while 1:
-                x_batch, y_batch = generator.next()
-                yield ([x_batch, y_batch], [y_batch, x_batch])
-
-        assert args.shift_fraction != 0, "No data augmentation if ``shift_fraction`` == 0."
-
-        model.fit_generator(
-            generator=train_generator(
-                x_train, y_train, args.batch_size, args.shift_fraction
-            ),
-            steps_per_epoch=int(y_train.shape[0] / args.batch_size),
-            epochs=args.epochs,
-            validation_data=[[x_test, y_test], [y_test, x_test]],
-            callbacks=[log, tb, checkpoint, lr_decay, timing],
+    def train_generator(x, y, batch_size, shift_fraction=0.):
+        # shift up to 2 pixel for MNIST
+        train_datagen = ImageDataGenerator(
+            width_shift_range=shift_fraction, height_shift_range=shift_fraction
         )
+        generator = train_datagen.flow(x, y, batch_size=batch_size)
+        while 1:
+            x_batch, y_batch = generator.next()
+            yield ([x_batch, y_batch], [y_batch, x_batch])
 
-    else:
-
-        assert args.shift_fraction == 0, "Set ``data_augmentation`` flag to shift pixels."
-
-        model.fit(
-            [x_train, y_train],
-            [y_train, x_train],
-            batch_size=args.batch_size,
-            epochs=args.epochs,
-            validation_data=[[x_test, y_test], [y_test, x_test]],
-            callbacks=[log, tb, checkpoint, lr_decay, timing],
-        )
+    model.fit_generator(
+        generator=train_generator(
+            x_train, y_train, args.batch_size, args.shift_fraction
+        ),
+        steps_per_epoch=int(y_train.shape[0] / args.batch_size),
+        epochs=args.epochs,
+        validation_data=[[x_test, y_test], [y_test, x_test]],
+        callbacks=[log, tb, checkpoint, lr_decay, timing],
+    )
 
     print("Time per epoch", timing.times)
 
@@ -326,7 +310,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dataset", default="cifar10", help="Available datasets: {'cifar10'}, 'mnist'."
     )
-    args = parser.parse_args()
+    args_ = parser.parse_args()
+    args = copy.deepcopy(args_)
+
+    if not args.data_augmentation:
+        args.shift_fraction = 0
+
     print(f"\nargs: {args}\n")
 
     if not os.path.exists(args.save_dir):

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -152,33 +152,42 @@ def train(model, data, args):
         metrics={"capsnet": "accuracy"},
     )
 
-    """
-    # Training without data augmentation:
-    model.fit([x_train, y_train], [y_train, x_train], batch_size=args.batch_size, epochs=args.epochs,
-              validation_data=[[x_test, y_test], [y_test, x_test]], callbacks=[log, tb, checkpoint, lr_decay])
-    """
+    if args.data_augmentation:
 
-    # Begin: Training with data augmentation -----------------------------------------------------#
-    def train_generator(x, y, batch_size, shift_fraction=0.):
-        train_datagen = ImageDataGenerator(
-            width_shift_range=shift_fraction, height_shift_range=shift_fraction
-        )  # shift up to 2 pixel for MNIST
-        generator = train_datagen.flow(x, y, batch_size=batch_size)
-        while 1:
-            x_batch, y_batch = generator.next()
-            yield ([x_batch, y_batch], [y_batch, x_batch])
+        def train_generator(x, y, batch_size, shift_fraction=0.):
+            # shift up to 2 pixel for MNIST
+            train_datagen = ImageDataGenerator(
+                width_shift_range=shift_fraction, height_shift_range=shift_fraction
+            )
+            generator = train_datagen.flow(x, y, batch_size=batch_size)
+            while 1:
+                x_batch, y_batch = generator.next()
+                yield ([x_batch, y_batch], [y_batch, x_batch])
 
-    # Training with data augmentation. If shift_fraction=0., also no augmentation.
-    model.fit_generator(
-        generator=train_generator(
-            x_train, y_train, args.batch_size, args.shift_fraction
-        ),
-        steps_per_epoch=int(y_train.shape[0] / args.batch_size),
-        epochs=args.epochs,
-        validation_data=[[x_test, y_test], [y_test, x_test]],
-        callbacks=[log, tb, checkpoint, lr_decay, timing],
-    )
-    # End: Training with data augmentation -------------------------------------------------------#
+        assert args.shift_fraction != 0, "No data augmentation if ``shift_fraction`` == 0."
+
+        model.fit_generator(
+            generator=train_generator(
+                x_train, y_train, args.batch_size, args.shift_fraction
+            ),
+            steps_per_epoch=int(y_train.shape[0] / args.batch_size),
+            epochs=args.epochs,
+            validation_data=[[x_test, y_test], [y_test, x_test]],
+            callbacks=[log, tb, checkpoint, lr_decay, timing],
+        )
+
+    else:
+
+        assert args.shift_fraction == 0, "Set ``data_augmentation`` flag to shift pixels."
+
+        model.fit(
+            [x_train, y_train],
+            [y_train, x_train],
+            batch_size=args.batch_size,
+            epochs=args.epochs,
+            validation_data=[[x_test, y_test], [y_test, x_test]],
+            callbacks=[log, tb, checkpoint, lr_decay],
+        )
 
     print("Time per epoch", timing.times)
 
@@ -297,9 +306,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--shift_fraction",
-        default=0.1,
+        default=0,
         type=float,
-        help="Fraction of pixels to shift at most in each direction.",
+        help="Fraction of pixels to shift at most in each direction.,
     )
     parser.add_argument(
         "--debug", action="store_true", help="Save weights by TensorBoard"
@@ -317,6 +326,9 @@ if __name__ == "__main__":
         "--weights",
         default=None,
         help="The path of the saved weights. Should be specified when testing",
+    )
+    parser.add_argument(
+        "--data_augmentation", default=False, help="Do data augmentation."
     )
     args = parser.parse_args()
     print(args)

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -45,11 +45,11 @@ def CapsNet(input_shape, n_class, routings):
     x = layers.Input(shape=input_shape)
 
     # Conventional Conv2D layers but more than in Sabour+2017
-    conv1 = layers.Conv2D(64, (3, 3), activation="relu")(x)
-    conv2 = layers.Conv2D(64, (3, 3), activation="relu")(conv1)
+    conv1 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(x)
+    conv2 = layers.Conv2D(filters=64, kernel_size=(3, 3), activation="relu")(conv1)
     pool1 = layers.AveragePooling2D((2, 2))(conv2)
-    conv3 = layers.Conv2D(128, (3, 3), activation="relu")(pool1)
-    conv4 = layers.Conv2D(128, (3, 3), activation="relu")(conv3)
+    conv3 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(pool1)
+    conv4 = layers.Conv2D(filters=128, kernel_size=(3, 3), activation="relu")(conv3)
 
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
@@ -332,9 +332,6 @@ if __name__ == "__main__":
         routings=args.routings,
     )
     model.summary()
-
-    for layer in model.layers:
-        print(layer.output_shape)
 
     # train or test
     if args.weights is not None:  # init the model weights with provided one

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -54,7 +54,7 @@ def CapsNet(input_shape, n_class, routings):
     # Layer 2: Conv2D layer with `squash` activation, then reshape to
     # [None, num_capsule, dim_capsule]
     primarycaps = PrimaryCap(
-        conv4, dim_capsule=8, n_channels=64, kernel_size=3, strides=2, padding="valid"
+        conv4, dim_capsule=8, n_channels=64, kernel_size=3, strides=1, padding="valid"
     )
 
     # Layer 3: Capsule layer. Routing algorithm works here.

--- a/capsulenet.py
+++ b/capsulenet.py
@@ -322,7 +322,7 @@ if __name__ == "__main__":
         "--dataset", default="mnist", help="Available datasets: {'mnist'}, 'cifar10'."
     )
     args = parser.parse_args()
-    print(f"\nargs: {args}\n")
+    print(args)
 
     if not os.path.exists(args.save_dir):
         os.makedirs(args.save_dir)

--- a/plot_accuracy_loss.py
+++ b/plot_accuracy_loss.py
@@ -1,7 +1,7 @@
 # @Author: Brett Andrews <andrews>
 # @Date:   2019-05-14 16:05:88
 # @Last modified by:   andrews
-# @Last modified time: 2019-05-20 10:05:90
+# @Last modified time: 2019-05-22 14:05:00
 
 import argparse
 from pathlib import Path
@@ -20,7 +20,7 @@ assert (args.run is not None) or (args.path is not None), "Must provide `model` 
 
 if args.path is None:
     path_models = Path.home() / "projects" / "photoz" / "CapsNet-Keras" / "models"
-    path = path_models / args.run.split("_")[0] / args.run
+    path = path_models / args.run.split("_")[0] / args.run / "result"
 
 else:
     run = None

--- a/plot_accuracy_loss.py
+++ b/plot_accuracy_loss.py
@@ -1,11 +1,7 @@
 # @Author: Brett Andrews <andrews>
 # @Date:   2019-05-14 16:05:88
 # @Last modified by:   andrews
-<<<<<<< HEAD
-# @Last modified time: 2019-05-22 21:05:51
-=======
-# @Last modified time: 2019-05-22 21:05:51
->>>>>>> refs/remotes/origin/enhancement-1-more_conv_layers
+# @Last modified time: 2019-05-30 13:05:15
 
 from pathlib import Path
 

--- a/plot_accuracy_loss.py
+++ b/plot_accuracy_loss.py
@@ -1,7 +1,7 @@
 # @Author: Brett Andrews <andrews>
 # @Date:   2019-05-14 16:05:88
 # @Last modified by:   andrews
-# @Last modified time: 2019-05-21 10:05:33
+# @Last modified time: 2019-05-22 21:05:18
 
 from pathlib import Path
 

--- a/plot_accuracy_loss.py
+++ b/plot_accuracy_loss.py
@@ -1,7 +1,7 @@
 # @Author: Brett Andrews <andrews>
 # @Date:   2019-05-14 16:05:88
 # @Last modified by:   andrews
-# @Last modified time: 2019-05-21 10:05:26
+# @Last modified time: 2019-05-21 10:05:33
 
 from pathlib import Path
 
@@ -18,7 +18,7 @@ def plot_accuracy_loss(run, path):
 
     if path is None:
         path_models = Path.home() / "projects" / "photoz" / "CapsNet-Keras" / "models"
-        path = path_models / run.split("_")[0] / run
+        path = path_models / run.split("_")[0] / run / "results"
 
     else:
         run = None

--- a/plot_accuracy_loss.py
+++ b/plot_accuracy_loss.py
@@ -1,45 +1,47 @@
 # @Author: Brett Andrews <andrews>
 # @Date:   2019-05-14 16:05:88
 # @Last modified by:   andrews
-# @Last modified time: 2019-05-20 10:05:90
+# @Last modified time: 2019-05-21 10:05:26
 
-import argparse
 from pathlib import Path
 
+import click
 import matplotlib.pyplot as plt
 import pandas as pd
 
 
-parser = argparse.ArgumentParser(description="Plot accuracy and loss.")
-parser.add_argument('--run', default=None, type=str, help="Run name.")
-parser.add_argument('--path', default=None, type=str, help="Path to output csv files.")
-args = parser.parse_args()
+@click.command()
+@click.option('--run', default=None, help="Run name.")
+@click.option('--path', default=None, type=click.Path(), help="Path to output csv files.")
+def plot_accuracy_loss(run, path):
+    assert (run is not None) or (path is not None), "Must provide `model` or `path`."
+
+    if path is None:
+        path_models = Path.home() / "projects" / "photoz" / "CapsNet-Keras" / "models"
+        path = path_models / run.split("_")[0] / run
+
+    else:
+        run = None
+
+    log = pd.read_csv(path / "log.csv")
+
+    fig, axes = plt.subplots(nrows=2)
+    axes[0].plot(log.epoch, log.capsnet_acc, label="train")
+    axes[0].plot(log.epoch, log.val_capsnet_acc, label="validation")
+    axes[0].set_ylabel("accuracy")
+    axes[0].legend()
+
+    axes[1].plot(log.epoch, log.capsnet_loss, label="margin")
+    axes[1].plot(log.epoch, log.decoder_loss, label="decoder")
+    axes[1].plot(log.epoch, log.loss, label="total")
+    axes[1].set_xlabel("epoch")
+    axes[1].set_ylabel("loss")
+    axes[1].legend()
+
+    fout = path / "accuracy_loss.pdf"
+    fig.savefig(fout)
+    click.echo(f"Wrote: {fout}")
 
 
-assert (args.run is not None) or (args.path is not None), "Must provide `model` or `path`."
-
-if args.path is None:
-    path_models = Path.home() / "projects" / "photoz" / "CapsNet-Keras" / "models"
-    path = path_models / args.run.split("_")[0] / args.run
-
-else:
-    run = None
-
-log = pd.read_csv(path / "log.csv")
-
-fig, axes = plt.subplots(nrows=2)
-axes[0].plot(log.epoch, log.capsnet_acc, label="train")
-axes[0].plot(log.epoch, log.val_capsnet_acc, label="validation")
-axes[0].set_ylabel("accuracy")
-axes[0].legend()
-
-axes[1].plot(log.epoch, log.capsnet_loss, label="margin")
-axes[1].plot(log.epoch, log.decoder_loss, label="decoder")
-axes[1].plot(log.epoch, log.loss, label="total")
-axes[1].set_xlabel("epoch")
-axes[1].set_ylabel("loss")
-axes[1].legend()
-
-fout = path / "accuracy_loss.pdf"
-fig.savefig(fout)
-print(f"Wrote: {fout}")
+if __name__ == "__main__":
+    plot_accuracy_loss()


### PR DESCRIPTION
Fixes #1 

Implements the conv2D layers from the [Keras CapsNet CIFAR-10 example code](https://keras.io/examples/cifar10_cnn/), which required reducing the `kernel_size` of the primary capsule layer from 9x9 to 3x3.

Validation accuracy improved from 56% to 73%.
